### PR TITLE
Fix compile error on GCC 5.4.0 (Ubuntu 16.04.1 LTS)

### DIFF
--- a/examples/tstcrc.c
+++ b/examples/tstcrc.c
@@ -99,7 +99,10 @@ int main( int argc, char *argv[] ) {
 	if ( do_ascii  ||  do_hex ) {
 
 		printf( "Input: " );
-		fgets( input_string, MAX_STRING_SIZE-1, stdin );
+		if( fgets( input_string, MAX_STRING_SIZE-1, stdin ) == NULL ){
+                   // Print the error
+                   perror("Error");
+                }
 	}
 
 	if ( do_ascii ) {


### PR DESCRIPTION
This PR fixes compilation with GCC 5.4.0, which ships with Ubuntu 16.04.1 LTS. The compiler warns about fgets() not returning a value, and since warnings are treated as errors, the compilation fails.

cc -c -Wall -Wextra -Wstrict-prototypes -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wredundant-decls -Wnested-externs -Werror -O3 -funsigned-char -Iinclude/ -oexamples/obj/tstcrc.o examples/tstcrc.c
examples/tstcrc.c: In function ‘main’:
examples/tstcrc.c:102:3: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
   fgets( input_string, MAX_STRING_SIZE-1, stdin );
   ^