### PR TITLE
Format checksum as char-sized int in checksum_NMEA

### DIFF
--- a/src/nmea-chk.c
+++ b/src/nmea-chk.c
@@ -69,7 +69,7 @@ unsigned char * checksum_NMEA( const unsigned char *input_str, unsigned char *re
 
 	while ( *ptr  &&  *ptr != '\r'  &&  *ptr != '\n'  &&  *ptr != '*' ) checksum ^= *ptr++;
 
-	snprintf( (char *) result, 3, "%02X", checksum );
+	snprintf( (char *) result, 3, "%02hhX", checksum );
 
 	return result; 
 


### PR DESCRIPTION
Compiler complains when trying to format it as a full-size int into a 3-byte string.