### PR TITLE
Add cross compile option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -146,6 +146,8 @@ make all
 
 make clean
 	cleans up the object files, library file and testall executable
+make CROSS_COMPILE=arm-linux-gnueabihf-
+	compile using arm-linux-gnueabihf cross compiler
 
 
 Lammert Bies

--- a/precalc/host_obj/README
+++ b/precalc/host_obj/README
@@ -1,0 +1,3 @@
+#
+# Directory for object files compiled for host when cross compiling
+#


### PR DESCRIPTION
Hi! This pull request enables cross compiling. For example, to cross compile the library to `armhf` using `x86_64` as host, compile it using `make CROSS_COMPILE=arm-linux-gnueabihf-`

Tested in Ubuntu 18.04 x86_64 as host and Ubuntu 16.04 armhf as target using `testall` program (All tests succeeded)

Cross compiler (`arm-linux-gnueabihf-gcc`): `gcc version 7.4.0 (Ubuntu/Linaro 7.4.0-1ubuntu1~18.04.1)`
Host compiler (to compile `prc`): `gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)`