### PR TITLE
CRC-CCITT32 and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,114 @@
+cmake_minimum_required(VERSION 3.0)
+project(crc LANGUAGES C)
+
+set(PROJECT_VERSION 2.1)
+set(PROJECT_DESCRIPTION "Multi platform MIT licensed CRC library in C")
+
+include(GNUInstallDirs)
+
+if(WIN32 AND (MSYS OR MINGW))
+	execute_process(COMMAND cygpath -ma /usr OUTPUT_VARIABLE CMAKE_INSTALL_PREFIX)
+	string(STRIP ${CMAKE_INSTALL_PREFIX} CMAKE_INSTALL_PREFIX)
+endif()
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(TAB_FILES
+        tab/gentab32.inc
+        tab/gentab64.inc
+)
+
+set(SOURCE_FILES
+	src/crcccitt32.c
+	src/crcccitt.c
+	src/crc8.c
+	src/crc16.c
+	src/crc32.c
+	src/crc64.c
+	src/crcsick.c
+	src/crckrmit.c
+	src/crcdnp.c
+	src/nmea-chk.c
+	${TAB_FILES}
+)
+
+set(INCLUDE_FILES
+	include/checksum.h
+)
+
+set(TAB32_FILES
+	tab/gentab32.inc
+   )
+set(TAB64_FILES
+	tab/gentab64.inc
+   )
+
+set(EXAMPLE_SOURCE_FILES
+	examples/tstcrc.c
+)
+
+set(TEST_SOURCE_FILES
+	test/testall.c
+	test/testall.h
+	test/testcrc.c
+	test/testnmea.c
+)
+
+set(PRECALC_SOURCE_FILES
+	precalc/crc32_table.c
+	precalc/crc64_table.c
+	precalc/precalc.c
+	precalc/precalc.h
+)
+
+# prc executable
+add_executable( prc ${PRECALC_SOURCE_FILES} )
+target_include_directories(prc PUBLIC
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/precalc>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+			)
+add_custom_command( OUTPUT ${TAB32_FILES} COMMAND prc --crc32 ${TAB32_FILES} DEPENDS prc ) 
+add_custom_command( OUTPUT ${TAB64_FILES} COMMAND prc --crc64 ${TAB64_FILES} DEPENDS prc )
+
+# libcrc library
+add_library( ${PROJECT_NAME} SHARED ${SOURCE_FILES} ${INCLUDE_FILES} ${TAB_FILES} )
+target_include_directories(${PROJECT_NAME} PUBLIC
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+			)
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER ${INCLUDE_FILES} ) 
+
+# tstcrc example
+add_executable( tstcrc ${EXAMPLE_SOURCE_FILES} ${INCLUDE_FILES} )
+target_link_libraries( tstcrc PRIVATE ${PROJECT_NAME} )
+set_target_properties( tstcrc PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+	${CMAKE_BINARY_DIR} )
+add_test(tstcrc tstcrc)
+
+# testall test
+add_executable( testall ${TEST_SOURCE_FILES} ${INCLUDE_FILES} )
+target_link_libraries( testall PRIVATE ${PROJECT_NAME} )
+set_target_properties( testall PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+	${CMAKE_BINARY_DIR} )
+add_test(testall testall)
+
+set(install_prefix "${CMAKE_INSTALL_PREFIX}")
+set(install_libdir "${CMAKE_INSTALL_LIBDIR}")
+set(install_includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+
+configure_file(lib${PROJECT_NAME}.pc.in ${PROJECT_BINARY_DIR}/lib${PROJECT_NAME}.pc @ONLY)
+
+set(ENV{PKG_CONFIG_PATH} "${PROJECT_BINARY_DIR}:$ENV{PKG_CONFIG_PATH}")
+
+install(TARGETS prc crc tstcrc testall EXPORT ${PROJECT_NAME}Config
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	PUBLIC_HEADER DESTINATION
+	${CMAKE_INSTALL_INCLUDEDIR}
+	)
+
+install(FILES lib${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)

--- a/Makefile.libcrc
+++ b/Makefile.libcrc
@@ -113,6 +113,7 @@ CFLAGS = -Wall -Wextra -Wstrict-prototypes -Wshadow -Wpointer-arith \
 	-Wcast-qual -Wcast-align -Wwrite-strings -Wredundant-decls \
 	-Wnested-externs -Werror -O3 \
 	-funsigned-char -I${INCDIR}
+PKG_CONFIG = pkg-config
 
 endif
 
@@ -168,7 +169,7 @@ testall${EXEEXT} :					\
 		${TSTDIR}${OBJDIR}testcrc${OBJEXT}	\
 		${TSTDIR}${OBJDIR}testnmea${OBJEXT}	\
 		${LIBDIR}libcrc${LIBEXT}		\
-		Makefile
+		Makefile.libcrc
 	${LINK} ${XFLAG}testall${EXEEXT}		\
 		${TSTDIR}${OBJDIR}testall${OBJEXT}	\
 		${TSTDIR}${OBJDIR}testcrc${OBJEXT}	\
@@ -185,7 +186,7 @@ ${BINDIR}prc${EXEEXT} :					\
 		${GENDIR}${OBJDIR}precalc${OBJEXT}	\
 		${GENDIR}${OBJDIR}crc32_table${OBJEXT}	\
 		${GENDIR}${OBJDIR}crc64_table${OBJEXT}	\
-		Makefile
+		Makefile.libcrc
 	${LINK}	${XFLAG}${BINDIR}prc${EXEEXT}		\
 		${GENDIR}${OBJDIR}precalc${OBJEXT}	\
 		${GENDIR}${OBJDIR}crc32_table${OBJEXT}	\
@@ -200,7 +201,7 @@ ${BINDIR}prc${EXEEXT} :					\
 tstcrc${EXEEXT} :					\
 		${EXADIR}${OBJDIR}tstcrc${OBJEXT}	\
 		${LIBDIR}libcrc${LIBEXT}		\
-		Makefile
+		Makefile.libcrc
 	${LINK}	${XFLAG}tstcrc${EXEEXT}			\
 		${EXADIR}${OBJDIR}tstcrc${OBJEXT}	\
 		${LIBDIR}libcrc${LIBEXT}
@@ -222,7 +223,7 @@ ${LIBDIR}libcrc${LIBEXT} :			\
 	${OBJDIR}crckrmit${OBJEXT}		\
 	${OBJDIR}crcsick${OBJEXT}		\
 	${OBJDIR}nmea-chk${OBJEXT}		\
-	Makefile
+	Makefile.libcrc
 		${RM}        ${LIBDIR}libcrc${LIBEXT}
 		${AR} ${ARQC}${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crc16${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crc32${OBJEXT}
@@ -283,4 +284,6 @@ ${GENDIR}${OBJDIR}crc32_table${OBJEXT}	: ${GENDIR}crc32_table.c ${GENDIR}precalc
 ${GENDIR}${OBJDIR}crc64_table${OBJEXT}	: ${GENDIR}crc64_table.c ${GENDIR}precalc.h ${INCDIR}checksum.h
 
 ${GENDIR}${OBJDIR}precalc${OBJEXT}	: ${GENDIR}precalc.c ${GENDIR}precalc.h
+
+libcrc.pc                               : libcrc.pc.in
 

--- a/Makefile.libcrc
+++ b/Makefile.libcrc
@@ -216,6 +216,7 @@ ${LIBDIR}libcrc${LIBEXT} :			\
 	${OBJDIR}crc16${OBJEXT}			\
 	${OBJDIR}crc32${OBJEXT}			\
 	${OBJDIR}crc64${OBJEXT}			\
+	${OBJDIR}crcccitt32${OBJEXT}            \
 	${OBJDIR}crcccitt${OBJEXT}		\
 	${OBJDIR}crcdnp${OBJEXT}		\
 	${OBJDIR}crckrmit${OBJEXT}		\
@@ -227,6 +228,7 @@ ${LIBDIR}libcrc${LIBEXT} :			\
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crc32${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crc64${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crc8${OBJEXT}
+		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crcccitt32${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crcccitt${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crcdnp${OBJEXT}
 		${AR} ${ARQ} ${LIBDIR}libcrc${LIBEXT} ${OBJDIR}crckrmit${OBJEXT}
@@ -255,6 +257,8 @@ ${OBJDIR}crc16${OBJEXT}			: ${SRCDIR}crc16.c ${INCDIR}checksum.h
 ${OBJDIR}crc32${OBJEXT}			: ${SRCDIR}crc32.c ${INCDIR}checksum.h ${TABDIR}gentab32.inc
 
 ${OBJDIR}crc64${OBJEXT}			: ${SRCDIR}crc64.c ${INCDIR}checksum.h ${TABDIR}gentab64.inc
+
+${OBJDIR}crcccitt32${OBJEXT}		: ${SRCDIR}crcccitt32.c ${INCDIR}checksum.h
 
 ${OBJDIR}crcccitt${OBJEXT}		: ${SRCDIR}crcccitt.c ${INCDIR}checksum.h
 

--- a/examples/tstcrc.c
+++ b/examples/tstcrc.c
@@ -63,6 +63,7 @@ int main( int argc, char *argv[] ) {
 	uint16_t crc_16_val;
 	uint16_t crc_16_modbus_val;
 	uint16_t crc_ccitt_ffff_val;
+	uint32_t crc_ccitt32_ffffffff_val;
 	uint16_t crc_ccitt_0000_val;
 	uint16_t crc_ccitt_1d0f_val;
 	uint16_t crc_dnp_val;
@@ -140,6 +141,7 @@ int main( int argc, char *argv[] ) {
 		crc_sick_val       = 0x0000;
 		crc_ccitt_0000_val = 0x0000;
 		crc_ccitt_ffff_val = 0xffff;
+		crc_ccitt32_ffffffff_val = 0xffffffffL;
 		crc_ccitt_1d0f_val = 0x1d0f;
 		crc_kermit_val     = 0x0000;
 		crc_32_val         = 0xffffffffL;
@@ -159,6 +161,7 @@ int main( int argc, char *argv[] ) {
 				crc_sick_val       = update_crc_sick(   crc_sick_val,       *ptr, prev_byte );
 				crc_ccitt_0000_val = update_crc_ccitt(  crc_ccitt_0000_val, *ptr            );
 				crc_ccitt_ffff_val = update_crc_ccitt(  crc_ccitt_ffff_val, *ptr            );
+				crc_ccitt32_ffffffff_val = update_crc_ccitt32(  crc_ccitt32_ffffffff_val, *ptr            );
 				crc_ccitt_1d0f_val = update_crc_ccitt(  crc_ccitt_1d0f_val, *ptr            );
 				crc_kermit_val     = update_crc_kermit( crc_kermit_val,     *ptr            );
 				crc_32_val         = update_crc_32(     crc_32_val,         *ptr            );
@@ -184,6 +187,7 @@ int main( int argc, char *argv[] ) {
 				crc_sick_val       = update_crc_sick(   crc_sick_val,       hex_val, prev_byte );
 				crc_ccitt_0000_val = update_crc_ccitt(  crc_ccitt_0000_val, hex_val            );
 				crc_ccitt_ffff_val = update_crc_ccitt(  crc_ccitt_ffff_val, hex_val            );
+				crc_ccitt32_ffffffff_val = update_crc_ccitt32(  crc_ccitt32_ffffffff_val, hex_val            );
 				crc_ccitt_1d0f_val = update_crc_ccitt(  crc_ccitt_1d0f_val, hex_val            );
 				crc_kermit_val     = update_crc_kermit( crc_kermit_val,     hex_val            );
 				crc_32_val         = update_crc_32(     crc_32_val,         hex_val            );
@@ -215,6 +219,7 @@ int main( int argc, char *argv[] ) {
 					crc_sick_val       = update_crc_sick(   crc_sick_val,       (unsigned char) ch, prev_byte );
 					crc_ccitt_0000_val = update_crc_ccitt(  crc_ccitt_0000_val, (unsigned char) ch            );
 					crc_ccitt_ffff_val = update_crc_ccitt(  crc_ccitt_ffff_val, (unsigned char) ch            );
+					crc_ccitt32_ffffffff_val = update_crc_ccitt32(  crc_ccitt32_ffffffff_val, (unsigned char) ch            );
 					crc_ccitt_1d0f_val = update_crc_ccitt(  crc_ccitt_1d0f_val, (unsigned char) ch            );
 					crc_kermit_val     = update_crc_kermit( crc_kermit_val,     (unsigned char) ch            );
 					crc_32_val         = update_crc_32(     crc_32_val,         (unsigned char) ch            );
@@ -243,15 +248,16 @@ int main( int argc, char *argv[] ) {
 		high_byte      = (crc_kermit_val & 0x00ff) << 8;
 		crc_kermit_val = low_byte | high_byte;
 
-		printf( "%s%s%s :\nCRC16              = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC16 (Modbus)     = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC16 (Sick)       = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC-CCITT (0x0000) = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC-CCITT (0xffff) = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC-CCITT (0x1d0f) = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC-CCITT (Kermit) = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC-DNP            = 0x%04" PRIX16 "      /  %" PRIu16 "\n"
-				  "CRC32              = 0x%08" PRIX32 "  /  %" PRIu32 "\n"
+		printf( "%s%s%s :\nCRC16              		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC16 (Modbus)     		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC16 (Sick)       		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC-CCITT (0x0000) 		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC-CCITT (0xffff) 		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC-CCITT32 (0xffffffff) 	= 0x%08" PRIX32 "  /  %" PRIu32 "\n"
+				  "CRC-CCITT (0x1d0f) 		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC-CCITT (Kermit) 		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC-DNP            		= 0x%04" PRIX16 "      /  %" PRIu16 "\n"
+				  "CRC32              		= 0x%08" PRIX32 "  /  %" PRIu32 "\n"
 				, (   do_ascii  ||    do_hex ) ? "\""    : ""
 				, ( ! do_ascii  &&  ! do_hex ) ? argv[a] : input_string
 				, (   do_ascii  ||    do_hex ) ? "\""    : ""
@@ -260,6 +266,7 @@ int main( int argc, char *argv[] ) {
 				, crc_sick_val,       crc_sick_val
 				, crc_ccitt_0000_val, crc_ccitt_0000_val
 				, crc_ccitt_ffff_val, crc_ccitt_ffff_val
+				, crc_ccitt32_ffffffff_val, crc_ccitt32_ffffffff_val
 				, crc_ccitt_1d0f_val, crc_ccitt_1d0f_val
 				, crc_kermit_val,     crc_kermit_val
 				, crc_dnp_val,        crc_dnp_val

--- a/include/checksum.h
+++ b/include/checksum.h
@@ -48,6 +48,7 @@
 #define		CRC_POLY_32		0xEDB88320ul
 #define		CRC_POLY_64		0x42F0E1EBA9EA3693ull
 #define		CRC_POLY_CCITT		0x1021
+#define		CRC_POLY_CCITT32        0x04C11DB7ul
 #define		CRC_POLY_DNP		0xA6BC
 #define		CRC_POLY_KERMIT		0x8408
 #define		CRC_POLY_SICK		0x8005
@@ -59,18 +60,19 @@
  * initialization of a CRC value for common used calculation methods.
  */
 
-#define		CRC_START_8		0x00
-#define		CRC_START_16		0x0000
-#define		CRC_START_MODBUS	0xFFFF
-#define		CRC_START_XMODEM	0x0000
-#define		CRC_START_CCITT_1D0F	0x1D0F
-#define		CRC_START_CCITT_FFFF	0xFFFF
-#define		CRC_START_KERMIT	0x0000
-#define		CRC_START_SICK		0x0000
-#define		CRC_START_DNP		0x0000
-#define		CRC_START_32		0xFFFFFFFFul
-#define		CRC_START_64_ECMA	0x0000000000000000ull
-#define		CRC_START_64_WE		0xFFFFFFFFFFFFFFFFull
+#define		CRC_START_8			0x00
+#define		CRC_START_16			0x0000
+#define		CRC_START_MODBUS		0xFFFF
+#define		CRC_START_XMODEM		0x0000
+#define		CRC_START_CCITT_1D0F		0x1D0F
+#define		CRC_START_CCITT_FFFF		0xFFFF
+#define		CRC_START_CCITT32_FFFFFFFF	0xFFFFFFFFul
+#define		CRC_START_KERMIT		0x0000
+#define		CRC_START_SICK			0x0000
+#define		CRC_START_DNP			0x0000
+#define		CRC_START_32			0xFFFFFFFFul
+#define		CRC_START_64_ECMA		0x0000000000000000ull
+#define		CRC_START_64_WE			0xFFFFFFFFFFFFFFFFull
 
 /*
  * Prototype list of global functions
@@ -84,6 +86,7 @@ uint64_t		crc_64_ecma(        const unsigned char *input_str, size_t num_bytes  
 uint64_t		crc_64_we(          const unsigned char *input_str, size_t num_bytes       );
 uint16_t		crc_ccitt_1d0f(     const unsigned char *input_str, size_t num_bytes       );
 uint16_t		crc_ccitt_ffff(     const unsigned char *input_str, size_t num_bytes       );
+uint32_t		crc_ccitt32_ffffffff(     const unsigned char *input_str, size_t num_bytes       );
 uint16_t		crc_dnp(            const unsigned char *input_str, size_t num_bytes       );
 uint16_t		crc_kermit(         const unsigned char *input_str, size_t num_bytes       );
 uint16_t		crc_modbus(         const unsigned char *input_str, size_t num_bytes       );
@@ -94,6 +97,7 @@ uint16_t		update_crc_16(      uint16_t crc, unsigned char c                     
 uint32_t		update_crc_32(      uint32_t crc, unsigned char c                          );
 uint64_t		update_crc_64_ecma( uint64_t crc, unsigned char c                          );
 uint16_t		update_crc_ccitt(   uint16_t crc, unsigned char c                          );
+uint32_t		update_crc_ccitt32(   uint32_t crc, unsigned char c                          );
 uint16_t		update_crc_dnp(     uint16_t crc, unsigned char c                          );
 uint16_t		update_crc_kermit(  uint16_t crc, unsigned char c                          );
 uint16_t		update_crc_sick(    uint16_t crc, unsigned char c, unsigned char prev_byte );

--- a/include/checksum.h
+++ b/include/checksum.h
@@ -78,29 +78,29 @@
  * Prototype list of global functions
  */
 
-unsigned char *		checksum_NMEA(      const unsigned char *input_str, unsigned char *result  );
-uint8_t			crc_8(              const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_16(             const unsigned char *input_str, size_t num_bytes       );
-uint32_t		crc_32(             const unsigned char *input_str, size_t num_bytes       );
-uint64_t		crc_64_ecma(        const unsigned char *input_str, size_t num_bytes       );
-uint64_t		crc_64_we(          const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_ccitt_1d0f(     const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_ccitt_ffff(     const unsigned char *input_str, size_t num_bytes       );
-uint32_t		crc_ccitt32_ffffffff(     const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_dnp(            const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_kermit(         const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_modbus(         const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_sick(           const unsigned char *input_str, size_t num_bytes       );
-uint16_t		crc_xmodem(         const unsigned char *input_str, size_t num_bytes       );
-uint8_t			update_crc_8(       uint8_t  crc, unsigned char c                          );
-uint16_t		update_crc_16(      uint16_t crc, unsigned char c                          );
-uint32_t		update_crc_32(      uint32_t crc, unsigned char c                          );
-uint64_t		update_crc_64_ecma( uint64_t crc, unsigned char c                          );
-uint16_t		update_crc_ccitt(   uint16_t crc, unsigned char c                          );
+unsigned char *		checksum_NMEA(        const unsigned char *input_str, unsigned char *result  );
+uint8_t			crc_8(                const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_16(               const unsigned char *input_str, size_t num_bytes       );
+uint32_t		crc_32(               const unsigned char *input_str, size_t num_bytes       );
+uint64_t		crc_64_ecma(          const unsigned char *input_str, size_t num_bytes       );
+uint64_t		crc_64_we(            const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_ccitt_1d0f(       const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_ccitt_ffff(       const unsigned char *input_str, size_t num_bytes       );
+uint32_t		crc_ccitt32_ffffffff( const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_dnp(              const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_kermit(           const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_modbus(           const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_sick(             const unsigned char *input_str, size_t num_bytes       );
+uint16_t		crc_xmodem(           const unsigned char *input_str, size_t num_bytes       );
+uint8_t			update_crc_8(         uint8_t  crc, unsigned char c                          );
+uint16_t		update_crc_16(        uint16_t crc, unsigned char c                          );
+uint32_t		update_crc_32(        uint32_t crc, unsigned char c                          );
+uint64_t		update_crc_64_ecma(   uint64_t crc, unsigned char c                          );
+uint16_t		update_crc_ccitt(     uint16_t crc, unsigned char c                          );
 uint32_t		update_crc_ccitt32(   uint32_t crc, unsigned char c                          );
-uint16_t		update_crc_dnp(     uint16_t crc, unsigned char c                          );
-uint16_t		update_crc_kermit(  uint16_t crc, unsigned char c                          );
-uint16_t		update_crc_sick(    uint16_t crc, unsigned char c, unsigned char prev_byte );
+uint16_t		update_crc_dnp(       uint16_t crc, unsigned char c                          );
+uint16_t		update_crc_kermit(    uint16_t crc, unsigned char c                          );
+uint16_t		update_crc_sick(      uint16_t crc, unsigned char c, unsigned char prev_byte );
 
 /*
  * Global CRC lookup tables

--- a/libcrc.pc.in
+++ b/libcrc.pc.in
@@ -1,0 +1,12 @@
+prefix=@install_prefix@
+exe_prefix=${prefix}
+libdir=${prefix}/@install_libdir@
+includedir=${prefix}/@install_includedir@
+
+Name: lib@PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir} -I${includedir}

--- a/src/crcccitt32.c
+++ b/src/crcccitt32.c
@@ -1,0 +1,133 @@
+/*
+ * Library: libcrc
+ * File:    src/crcccitt32.c
+ * Author:  Lammert Bies
+ *
+ * This file is licensed under the MIT License as stated below
+ *
+ * Copyright (c) 1999-2016 Lammert Bies
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Description
+ * -----------
+ * The module src/crcccitt32.c contains routines which are used to calculate the
+ * CCITT32 CRC values of a string of bytes.
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include "checksum.h"
+
+static uint32_t         crc_ccitt32_generic( const unsigned char *input_str, size_t num_bytes, uint32_t start_value );
+static void             init_crcccitt32_tab( uint32_t poly, uint32_t swapped);
+
+static bool             crc_tabccitt32_init       = false;
+static uint32_t         crc_tabccitt32[256];
+
+/*
+ * uint32_t crc_ccitt32_ffffffff( const unsigned char *input_str, size_t num_bytes );
+ *
+ * The function crc_ccitt32_ffffffff() performs a one-pass calculation of the CCITT
+ * CRC for a byte string that has been passed as a parameter. The initial value
+ * 0xffffffff is used for the CRC.
+ */
+
+uint32_t crc_ccitt32_ffffffff( const unsigned char *input_str, size_t num_bytes ) {
+
+	return crc_ccitt32_generic( input_str, num_bytes, CRC_START_CCITT32_FFFFFFFF );
+
+}  /* crc_ccitt32_ffffffff */
+
+/*
+ * static uint32_t crc_ccitt32_generic( const unsigned char *input_str, size_t num_bytes, uint32_t start_value );
+ *
+ * The function crc_ccitt32_generic() is a generic implementation of the CCITT32
+ * algorithm for a one-pass calculation of the CRC for a byte string. The
+ * function accepts an initial start value for the crc.
+ */
+
+static uint32_t crc_ccitt32_generic( const unsigned char *input_str, size_t num_bytes, uint32_t start_value ) {
+
+	uint32_t crc;
+	const unsigned char *ptr;
+	size_t a;
+
+	if ( ! crc_tabccitt32_init ) init_crcccitt32_tab(CRC_POLY_CCITT32, 0);
+
+	crc = start_value;
+	ptr = input_str;
+
+	if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+
+		crc = ((crc << 8)&0xffffff00) ^ crc_tabccitt32[ (((crc >> 24)&0xff) ^ *ptr++) ];
+	}
+
+	return crc;
+
+}  /* crc_ccitt32_generic */
+
+/*
+ * uint32_t update_crc_ccitt32( uint32_t crc, unsigned char c );
+ *
+ * The function update_crc_ccitt32() calculates a new CRC-CCITT32 value based on
+ * the previous value of the CRC and the next byte of the data to be checked.
+ */
+
+uint32_t update_crc_ccitt32( uint32_t crc, unsigned char c ) {
+
+	if ( ! crc_tabccitt32_init ) init_crcccitt32_tab(CRC_POLY_CCITT32, 0);
+
+	return ((crc << 8)&0xffffff00) ^ crc_tabccitt32[ ((crc >> 24) ^ c) & 0xff ];
+
+}  /* update_crc_ccitt32 */
+
+/*
+ * static void init_crcccitt32_tab( void );
+ *
+ * For optimal performance, the routine to calculate the CRC-CCITT32 uses a
+ * lookup table with pre-compiled values that can be directly applied in the
+ * XOR action. This table is created at the first call of the function by the
+ * init_crcccitt32_tab() routine.
+ */
+
+static void init_crcccitt32_tab( uint32_t poly, uint32_t swapped) {
+
+	int i;
+	int j;
+	uint32_t crc;
+
+	for (i=0; i<256; i++) {
+		if(swapped) {
+			crc = crc & 1 ? (crc >> 1)^poly : crc >> 1;
+			for (crc=i,j=8; --j >=0 ;) {
+				crc = crc & 1 ? (crc >> 1)^poly : crc >> 1;
+			}
+		}
+		else {
+			for (crc=i<<24, j=8; --j >= 0;) {
+				crc = crc & 0x80000000 ? (crc << 1)^poly : crc << 1;
+			}
+		}
+		crc_tabccitt32[i] = crc;
+	}
+
+	crc_tabccitt32_init = true;
+
+}  /* init_crcccitt32_tab */

--- a/test/testcrc.c
+++ b/test/testcrc.c
@@ -41,30 +41,32 @@
 
 #include "../include/checksum.h"
 
-						/************************************************/
-struct chk_tp {					/*						*/
-	const char *	input;			/* The input string to be checked		*/
-	uint8_t		crc8;			/* The  8 bit wide CRC8 of the input string	*/
-	uint16_t	crc16;			/* The 16 bit wide CRC16 of the input string	*/
-	uint32_t	crc32;			/* The 32 bit wide CRC32 of the input string	*/
-	uint64_t	crc64_ecma;		/* The 64 bit wide CRC64-ECMA of the input	*/
-	uint64_t	crc64_we;		/* The 64 bit wide CRC64-WE of the input string	*/
-	uint16_t	crcdnp;			/* The 16 bit wide DNP CRC of the string	*/
-	uint16_t	crcmodbus;		/* The 16 bit wide Modbus CRC of the string	*/
-	uint16_t	crcsick;		/* The 16 bit wide Sick CRC of the string	*/
-	uint16_t	crcxmodem;		/* The 16 bit wide XModem CRC of the string	*/
-	uint16_t	crc1d0f;		/* The 16 bit wide CCITT CRC with 1D0F start	*/
-	uint16_t	crcffff;		/* The 16 bit wide CCITT CRC with FFFF start	*/
-	uint16_t	crckermit;		/* The 16 bit wide CRC Kermit of the string	*/
-};						/*						*/
-						/************************************************/
+						/***************************************************/
+struct chk_tp {					/*						   */
+	const char *	input;			/* The input string to be checked		   */
+	uint8_t		crc8;			/* The  8 bit wide CRC8 of the input string	   */
+	uint16_t	crc16;			/* The 16 bit wide CRC16 of the input string	   */
+	uint32_t	crc32;			/* The 32 bit wide CRC32 of the input string	   */
+	uint64_t	crc64_ecma;		/* The 64 bit wide CRC64-ECMA of the input	   */
+	uint64_t	crc64_we;		/* The 64 bit wide CRC64-WE of the input string	   */
+	uint16_t	crcdnp;			/* The 16 bit wide DNP CRC of the string	   */
+	uint16_t	crcmodbus;		/* The 16 bit wide Modbus CRC of the string	   */
+	uint16_t	crcsick;		/* The 16 bit wide Sick CRC of the string	   */
+	uint16_t	crcxmodem;		/* The 16 bit wide XModem CRC of the string   	   */
+	uint16_t	crc1d0f;		/* The 16 bit wide CCITT CRC with 1D0F start	   */
+	uint16_t	crcffff;		/* The 16 bit wide CCITT CRC with FFFF start	   */
+	uint32_t        crcccitt32ffffffff;	/* The 32 bit wide CCITT32 CRC with FFFFFFFF start */
+	uint16_t	crckermit;		/* The 16 bit wide CRC Kermit of the string	   */
+};						/*						   */
+						/***************************************************/
 
 static struct chk_tp checks[] = {
-	{ "123456789",    0xA2, 0xBB3D, 0xCBF43926ul, 0x6C40DF5F0B497347ull, 0x62EC59E3F1A4F00Aull, 0x82EA, 0x4B37, 0x56A6, 0x31C3, 0xE5CC, 0x29B1, 0x8921 },
-	{ "Lammert Bies", 0xA5, 0xB638, 0x43C04CA6ul, 0xF806F4F5C0F3257Cull, 0xFE25A9F50630F789ull, 0x4583, 0xB45C, 0x1108, 0xCEC8, 0x67A2, 0x4A31, 0xF80D },
-	{ "",             0x00, 0x0000, 0x00000000ul, 0x0000000000000000ull, 0x0000000000000000ull, 0xFFFF, 0xFFFF, 0x0000, 0x0000, 0x1D0F, 0xFFFF, 0x0000 },
-	{ " ",            0x86, 0xD801, 0xE96CCF45ul, 0xCC7AF1FF21C30BDEull, 0x568617D9EF46BE26ull, 0x50D6, 0x98BE, 0x2000, 0x2462, 0xE8FE, 0xC592, 0x0221 },
-	{ NULL,           0,    0,      0,            0,                     0,                     0,      0,      0,      0,      0,      0,      0      }
+	{ "123456789",    0xA2, 0xBB3D, 0xCBF43926ul,  0x6C40DF5F0B497347ull, 0x62EC59E3F1A4F00Aull, 0x82EA, 0x4B37, 0x56A6, 0x31C3, 0xE5CC, 0x29B1, 0x0376E6E7ul, 0x8921 },
+	
+	{ "Lammert Bies", 0xA5, 0xB638, 0x43C04CA6ul, 0xF806F4F5C0F3257Cull, 0xFE25A9F50630F789ull, 0x4583, 0xB45C, 0x1108, 0xCEC8, 0x67A2, 0x4A31, 0xDC7513E5ul, 0xF80D },
+	{ "",             0x00, 0x0000, 0x00000000ul, 0x0000000000000000ull, 0x0000000000000000ull, 0xFFFF, 0xFFFF, 0x0000, 0x0000, 0x1D0F, 0xFFFF, 0xFFFFFFFFul, 0x0000 },
+	{ " ",            0x86, 0xD801, 0xE96CCF45ul, 0xCC7AF1FF21C30BDEull, 0x568617D9EF46BE26ull, 0x50D6, 0x98BE, 0x2000, 0x2462, 0xE8FE, 0xC592, 0xD62B0954, 0x0221 },
+	{ NULL,           0,    0,      0,            0,                     0,                     0,      0,      0,      0,      0,      0,      0,      0 }
 };
 
 /*
@@ -89,6 +91,7 @@ int test_crc( bool verbose ) {
 	uint16_t crc1d0f;
 	uint16_t crcffff;
 	uint16_t crckermit;
+	uint32_t crcccitt32ffffffff;
 	uint32_t crc32;
 	uint64_t crc64_ecma;
 	uint64_t crc64_we;
@@ -103,18 +106,19 @@ int test_crc( bool verbose ) {
 		ptr = (const unsigned char *) checks[a].input;
 		len = strlen( checks[a].input );
 
-		crc8       = crc_8(          ptr, len );
-		crc16      = crc_16(         ptr, len );
-		crc32      = crc_32(         ptr, len );
-		crc64_ecma = crc_64_ecma(    ptr, len );
-		crc64_we   = crc_64_we(      ptr, len );
-		crcdnp     = crc_dnp(        ptr, len );
-		crcmodbus  = crc_modbus(     ptr, len );
-		crcsick    = crc_sick(       ptr, len );
-		crcxmodem  = crc_xmodem(     ptr, len );
-		crc1d0f    = crc_ccitt_1d0f( ptr, len );
-		crcffff    = crc_ccitt_ffff( ptr, len );
-		crckermit  = crc_kermit(     ptr, len );
+		crc8               = crc_8(                ptr, len );
+		crc16              = crc_16(               ptr, len );
+		crc32              = crc_32(               ptr, len );
+		crcccitt32ffffffff = crc_ccitt32_ffffffff( ptr, len );
+		crc64_ecma         = crc_64_ecma(          ptr, len );
+		crc64_we           = crc_64_we(            ptr, len );
+		crcdnp             = crc_dnp(              ptr, len );
+		crcmodbus          = crc_modbus(           ptr, len );
+		crcsick            = crc_sick(             ptr, len );
+		crcxmodem          = crc_xmodem(           ptr, len );
+		crc1d0f            = crc_ccitt_1d0f(       ptr, len );
+		crcffff            = crc_ccitt_ffff(       ptr, len );
+		crckermit          = crc_kermit(           ptr, len );
 
 		if ( crc8 != checks[a].crc8 ) {
 
@@ -134,6 +138,13 @@ int test_crc( bool verbose ) {
 
 			if ( verbose ) printf( "\n    FAIL: CRC32 \"%s\" returns 0x%08" PRIX32 ", not 0x%08" PRIX32
 							, checks[a].input, crc32, checks[a].crc32 );
+			errors++;
+		}
+
+		if ( crcccitt32ffffffff != checks[a].crcccitt32ffffffff ) {
+
+			if ( verbose ) printf( "\n    FAIL: CRC CCITT32 ffffffff\"%s\" returns 0x%08" PRIX32 ", not 0x%08" PRIX32
+							, checks[a].input, crcccitt32ffffffff, checks[a].crcccitt32ffffffff );
 			errors++;
 		}
 


### PR DESCRIPTION
Moves old build system to Makefile.libcrc and includes the new changes
CCITT32-CRC based on https://github.com/dgilman/macutils