### PR TITLE
Added PlatformIO library manifest: library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,33 @@
+{
+  "name": "LibCRC",
+  "version": "2.0.0",
+  "keywords": "crc crc8 crc16 crc32",
+  "description": "LibCRC - Multi platform MIT licensed CRC library in C",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lammertb/libcrc"
+  },
+  "authors": [{
+    "name": "Lammert Bies",
+    "email": "github@linocomm.net"
+  }],
+  "frameworks": "*",
+  "platforms": "*",
+  "export": {
+    "include": [
+      "include/*",
+      "src/*.c",
+      "examples/tstcrc.c"
+    ]
+  },
+  "examples": {
+    "tstcrc": {
+      "name": "tstcrc",
+      "description": "Test program for LibCRC",
+      "include": [
+        "examples/tstcrc.c"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
PlatformIO is very popular for embed develop, so I added library manifest.

I temporary [published](https://registry.platformio.org/libraries/hacker-cb/LibCRC) it under my account

You can [install cli](https://docs.platformio.org/en/latest/core/index.html) and publish it under your account with `platformio pkg publish --owner=lammertb` command.

I will delete package from my account in this case.

